### PR TITLE
Make Fixtures.insert return document _id

### DIFF
--- a/fixtures.js
+++ b/fixtures.js
@@ -80,7 +80,7 @@ Fixtures = {
 
         Counter.added(collection, 1);
 
-        return id;
+        return _id;
 
       }
 


### PR DESCRIPTION
As the documentation specifies, `Fixtures.insert` should return the newly created document's `_id`.
